### PR TITLE
fix tmp directory is cleaned by system after reboot

### DIFF
--- a/Welly/WLConnection.m
+++ b/Welly/WLConnection.m
@@ -231,7 +231,7 @@
 
 - (NSString *)identityFile {
     if (!_identityFile) {
-        _identityFile = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString];
+        _identityFile = [[WLGlobalConfig tmpDirectory] stringByAppendingPathComponent:[NSUUID UUID].UUIDString];
     }
     return _identityFile;
 }

--- a/Welly/WLConnection.m
+++ b/Welly/WLConnection.m
@@ -231,7 +231,7 @@
 
 - (NSString *)identityFile {
     if (!_identityFile) {
-        _identityFile = [[WLGlobalConfig tmpDirectory] stringByAppendingPathComponent:[NSUUID UUID].UUIDString];
+        _identityFile = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString];
     }
     return _identityFile;
 }

--- a/Welly/WLGlobalConfig.h
+++ b/Welly/WLGlobalConfig.h
@@ -112,6 +112,8 @@ NSString *const WLEnglishFontSizeKeyName;
 + (void)initializeCache;
 + (NSString *)cacheDirectory;
 
++ (NSString *)tmpDirectory;
+
 - (void)restoreSettings;
 @property (NS_NONATOMIC_IOSONLY, copy) NSDictionary *sizeParameters;
 @end

--- a/Welly/WLGlobalConfig.m
+++ b/Welly/WLGlobalConfig.m
@@ -579,6 +579,29 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(WLGlobalConfig)
     [[NSFileManager defaultManager] createDirectoryAtPath:cacheDir withIntermediateDirectories:YES attributes:nil error:NULL];
 }
 
++ (NSString *)tmpDirectory {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+    NSString *appSupportDir = [paths firstObject];
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleNameKey];
+    NSString *appPath = [appSupportDir stringByAppendingPathComponent:appName];
+    NSString *fullPath = [appPath stringByAppendingPathComponent:@"tmp"];
+
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *error;
+    if (![fileManager fileExistsAtPath:fullPath]) {
+        [fileManager createDirectoryAtPath:fullPath
+               withIntermediateDirectories:YES
+                                attributes:nil
+                                     error:&error];
+        if (error) {
+            NSLog(@"Error creating directory: %@", error.localizedDescription);
+            return nil;
+        }
+    }
+    return fullPath;
+}
+
 #pragma mark -
 #pragma mark Query Global Config
 - (NSSize)contentSize {

--- a/Welly/WLPTY.m
+++ b/Welly/WLPTY.m
@@ -93,7 +93,7 @@
             if (identityFile) {
                 path = [NSString stringWithFormat:@"/usr/bin/ssh -i %@ -o StrictHostKeyChecking=no -o UserKnownHostsFile=%@",
                         identityFile,
-                        [NSTemporaryDirectory() stringByAppendingPathComponent:@"known_hosts"]];
+                        [[WLGlobalConfig tmpDirectory] stringByAppendingPathComponent:@"known_hosts"]];
                 fmt = @"%@%@ -p %4$@ -x %3$@";
             } else {
                 path = [NSString stringWithFormat:@"%@ -%d",
@@ -233,7 +233,7 @@
         argv[i] = (char *)[a[i] UTF8String];
         argv[n] = NULL;
         char *envp[2];
-        envp[0] = (char *)[@"PUTTYDIR=" stringByAppendingString:NSTemporaryDirectory()].UTF8String;
+        envp[0] = (char *)[@"PUTTYDIR=" stringByAppendingString:[WLGlobalConfig tmpDirectory]].UTF8String;
         envp[1] = NULL;
         execve(argv[0], argv, envp);
         perror(argv[0]);


### PR DESCRIPTION
https://www.newsmth.net/nForum/#!article/AppleDev/4341
有人反应了这么一个问题
做了下修改
把所有的临时路径都移动到了沙盒的Application Support/Welly/tmp下面
也不知道合适不合适